### PR TITLE
Add data table for scheduled messages

### DIFF
--- a/src/components/SchedulesDataTable.vue
+++ b/src/components/SchedulesDataTable.vue
@@ -4,7 +4,7 @@
     :default-sort="{ prop: 'next_run', order: 'ascending' }"
   >
     <el-table-column
-      v-for="col in tableLabel"
+      v-for="col in tableColumn"
       :key="col.id"
       :prop="col.prop"
       :label="col.label"
@@ -24,7 +24,9 @@
 
 <script>
 import { ElTable, ElTableColumn, ElPagination } from 'element-plus';
-import 'element-plus/dist/index.css';
+import 'element-plus/es/components/table/style/css';
+import 'element-plus/es/components/table-column/style/css';
+import 'element-plus/es/components/pagination/style/css';
 
 export default {
   name: 'SchedulesDataTable',
@@ -87,7 +89,7 @@ export default {
           active: 'Active',
         },
       ],
-      tableLabel: [
+      tableColumn: [
         {
           id: 1,
           label: 'Message',

--- a/src/components/SchedulesDataTable.vue
+++ b/src/components/SchedulesDataTable.vue
@@ -23,8 +23,16 @@
 </template>
 
 <script>
+import { ElTable, ElTableColumn, ElPagination } from 'element-plus';
+import 'element-plus/dist/index.css';
+
 export default {
   name: 'SchedulesDataTable',
+  components: {
+    ElTable,
+    ElTableColumn,
+    ElPagination,
+  },
   data() {
     return {
       tableData: [

--- a/src/components/SchedulesDataTable.vue
+++ b/src/components/SchedulesDataTable.vue
@@ -1,0 +1,112 @@
+<template>
+  <el-table
+    :data="tableData"
+    :default-sort="{ prop: 'next_run', order: 'ascending' }"
+  >
+    <el-table-column
+      v-for="col in tableLabel"
+      :key="col.id"
+      :prop="col.prop"
+      :label="col.label"
+      :sortable="col.isSortable"
+      :column-key="col.prop"
+      :width="col.width"
+    />
+    <el-table-column prop="action" label="">
+      <div class="action-icons">
+        <i class="fa-solid fa-pencil icon"></i>
+        <i class="fa-solid fa-trash icon"></i>
+      </div>
+    </el-table-column>
+  </el-table>
+  <el-pagination layout="prev, pager, next" :total="50"> </el-pagination>
+</template>
+
+<script>
+export default {
+  name: 'SchedulesDataTable',
+  data() {
+    return {
+      tableData: [
+        {
+          message: 'First Message',
+          next_run: '2016-04-03',
+          active: 'Active',
+        },
+        {
+          message: 'Second Message',
+          next_run: '2016-11-03',
+          active: 'Inactive',
+        },
+        {
+          message: 'Third Message',
+          next_run: '2015-08-07',
+          active: 'Active',
+        },
+        {
+          message: 'Fourth Message',
+          next_run: '2016-01-03',
+          active: 'Active',
+        },
+        {
+          message: 'Fifth Message',
+          next_run: '2012-09-09',
+          active: 'Active',
+        },
+        {
+          message: 'Sixth Message',
+          next_run: '2017-02-04',
+          active: 'Active',
+        },
+        {
+          message: 'Seventh Message',
+          next_run: '2015-08-07',
+          active: 'Active',
+        },
+        {
+          message: 'Eight Message',
+          next_run: '2016-01-03',
+          active: 'Active',
+        },
+        {
+          message: 'Nineth Message',
+          next_run: '2012-09-09',
+          active: 'Inactive',
+        },
+        {
+          message: 'Tenth Message',
+          next_run: '2017-02-04',
+          active: 'Active',
+        },
+      ],
+      tableLabel: [
+        {
+          id: 1,
+          label: 'Message',
+          prop: 'message',
+          isSortable: true,
+          width: '350',
+        },
+        {
+          id: 2,
+          label: 'Next Run',
+          prop: 'next_run',
+          isSortable: true,
+          width: '135',
+        },
+        {
+          id: 3,
+          label: 'Active',
+          prop: 'active',
+          isSortable: true,
+          width: '135',
+        },
+      ],
+    };
+  },
+};
+</script>
+
+<style lang="scss">
+@import '../style/components/data-table.scss';
+</style>


### PR DESCRIPTION
## Changes
- Add data table for displaying scheduled messages
- Add sorting functionality to sort schedules messages by text, next run date and active status
- Add pagination to group scheduled messages into pages

## Reference
https://trello.com/c/NBBtAr7k/58-task-features-schedulesdatatable