### PR TITLE
Add data table for message triggers

### DIFF
--- a/src/components/MessagesDataTable.vue
+++ b/src/components/MessagesDataTable.vue
@@ -4,7 +4,7 @@
     :default-sort="{ prop: 'date', order: 'descending' }"
   >
     <el-table-column
-      v-for="col in tableLabel"
+      v-for="col in tableColumns"
       :key="col.id"
       :prop="col.prop"
       :label="col.label"
@@ -24,7 +24,9 @@
 
 <script>
 import { ElTable, ElTableColumn, ElPagination } from 'element-plus';
-import 'element-plus/dist/index.css';
+import 'element-plus/es/components/table/style/css';
+import 'element-plus/es/components/table-column/style/css';
+import 'element-plus/es/components/pagination/style/css';
 
 export default {
   name: 'MessagesDataTable',
@@ -87,7 +89,7 @@ export default {
           date: '2017-02-04',
         },
       ],
-      tableLabel: [
+      tableColumns: [
         {
           id: 1,
           label: 'Title',

--- a/src/components/TriggersDataTable.vue
+++ b/src/components/TriggersDataTable.vue
@@ -23,8 +23,16 @@
 </template>
 
 <script>
+import { ElTable, ElTableColumn, ElPagination } from 'element-plus';
+import 'element-plus/dist/index.css';
+
 export default {
   name: 'TriggersDataTable',
+  components: {
+    ElTable,
+    ElTableColumn,
+    ElPagination,
+  },
   data() {
     return {
       tableData: [

--- a/src/components/TriggersDataTable.vue
+++ b/src/components/TriggersDataTable.vue
@@ -1,0 +1,129 @@
+<template>
+  <el-table
+    :data="tableData"
+    :default-sort="{ prop: 'date', order: 'descending' }"
+  >
+    <el-table-column
+      v-for="col in tableLabel"
+      :key="col.id"
+      :prop="col.prop"
+      :label="col.label"
+      :sortable="col.isSortable"
+      :column-key="col.prop"
+      :width="col.width"
+    />
+    <el-table-column prop="action" label="">
+      <div class="action-icons">
+        <i class="fa-solid fa-clipboard-check icon"></i>
+        <i class="fa-solid fa-bell icon"></i>
+      </div>
+    </el-table-column>
+  </el-table>
+  <el-pagination layout="prev, pager, next" :total="50"> </el-pagination>
+</template>
+
+<script>
+export default {
+  name: 'TriggersDataTable',
+  data() {
+    return {
+      tableData: [
+        {
+          message: 'First Message',
+          trigger: '2016-04-03',
+          channel: 'Channel 1',
+          active: 'Active',
+        },
+        {
+          message: 'Second Message',
+          trigger: '2016-11-03',
+          channel: 'Channel 2',
+          active: 'Active',
+        },
+        {
+          message: 'Third Message',
+          trigger: '2015-08-07',
+          channel: 'Channel 3',
+          active: 'Active',
+        },
+        {
+          message: 'Fourth Message',
+          trigger: '2016-01-03',
+          channel: 'Channel 4',
+          active: 'Active',
+        },
+        {
+          message: 'Fifth Message',
+          trigger: '2012-09-09',
+          channel: 'Channel 5',
+          active: 'Active',
+        },
+        {
+          message: 'Sixth Message',
+          trigger: '2017-02-04',
+          channel: 'Channel 6',
+          active: 'Active',
+        },
+        {
+          message: 'Seventh Message',
+          trigger: '2015-08-07',
+          channel: 'Channel 7',
+          active: 'Active',
+        },
+        {
+          message: 'Eight Message',
+          trigger: '2016-01-03',
+          channel: 'Channel 8',
+          active: 'Active',
+        },
+        {
+          message: 'NIneth Message',
+          trigger: '2012-09-09',
+          channel: 'Channel 9',
+          active: 'Active',
+        },
+        {
+          message: 'Tenth Message',
+          trigger: '2017-02-04',
+          channel: 'Channel 10',
+          active: 'Active',
+        },
+      ],
+      tableLabel: [
+        {
+          id: 1,
+          label: 'Message',
+          prop: 'message',
+          isSortable: true,
+          width: '350',
+        },
+        {
+          id: 2,
+          label: 'Trigger',
+          prop: 'trigger',
+          isSortable: true,
+          width: '135',
+        },
+        {
+          id: 3,
+          label: 'Channel',
+          prop: 'channel',
+          isSortable: true,
+          width: '160',
+        },
+        {
+          id: 4,
+          label: 'Active',
+          prop: 'active',
+          isSortable: true,
+          width: '135',
+        },
+      ],
+    };
+  },
+};
+</script>
+
+<style lang="scss">
+@import '../style/components/data-table.scss';
+</style>

--- a/src/components/TriggersDataTable.vue
+++ b/src/components/TriggersDataTable.vue
@@ -4,7 +4,7 @@
     :default-sort="{ prop: 'date', order: 'descending' }"
   >
     <el-table-column
-      v-for="col in tableLabel"
+      v-for="col in tableColumns"
       :key="col.id"
       :prop="col.prop"
       :label="col.label"
@@ -24,7 +24,9 @@
 
 <script>
 import { ElTable, ElTableColumn, ElPagination } from 'element-plus';
-import 'element-plus/dist/index.css';
+import 'element-plus/es/components/table/style/css';
+import 'element-plus/es/components/table-column/style/css';
+import 'element-plus/es/components/pagination/style/css';
 
 export default {
   name: 'TriggersDataTable',
@@ -97,7 +99,7 @@ export default {
           active: 'Active',
         },
       ],
-      tableLabel: [
+      tableColumns: [
         {
           id: 1,
           label: 'Message',


### PR DESCRIPTION
## Changes 
- Add data table for displaying triggered messages
- Add pagination to group triggered messages into pages
- Add sorting functionality to sort messages by the trigger date, channel name and active status

## Reference
https://trello.com/c/Z3FfKSTQ/60-task-features-triggersdatatable